### PR TITLE
fix(draw): 高德地图下编辑多边形中间点错乱问题&添加绘制组件demo

### DIFF
--- a/docs/demo/draw_control.jsx
+++ b/docs/demo/draw_control.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Scene } from '@antv/l7';
+import { DrawControl } from '@antv/l7-draw';
+import { GaodeMap } from '@antv/l7-maps';
+
+export default () => {
+  React.useEffect(() => {
+    const scene = new Scene({
+      id: 'map',
+      map: new GaodeMap({
+        pitch: 0,
+        style: 'light',
+        center: [116.30470275878906, 39.88352811449648],
+        zoom: 12,
+      }),
+    });
+    scene.on('loaded', () => {
+      const drawControl = new DrawControl(scene, {
+        position: 'topright',
+        layout: 'horizontal', // horizontal vertical
+        controls: {
+          point: true,
+          polygon: true,
+          line: true,
+          circle: true,
+          rect: true,
+          delete: true,
+        },
+      });
+      scene.on('click', () => {});
+      drawControl.on('draw.update', e => {
+        console.log('update', e);
+      });
+      scene.addControl(drawControl);
+    });
+  }, []);
+
+  return (
+    <div
+      style={{
+        height: '400px',
+        position: 'relative',
+      }}
+      id="map"
+    ></div>
+  );
+};

--- a/docs/draw_control.en.md
+++ b/docs/draw_control.en.md
@@ -140,7 +140,7 @@ drawControl 的事件类型和每个 Draw 的事件一致，如果在 drawContro
 图形更新时触发该事件，图形的平移，顶点的编辑
 
 ```javascript
-drawControl.on('draw.delete', (e) => {});
+drawControl.on('draw.delete', e => {});
 ```
 
 ### style
@@ -243,3 +243,7 @@ const style = {
   },
 };
 ```
+
+## demo
+
+<code src="./demo/draw_control.jsx" />

--- a/docs/draw_control.zh.md
+++ b/docs/draw_control.zh.md
@@ -150,7 +150,7 @@ drawControl 的事件类型和每个 Draw 的事件一致，如果在 drawContro
 图形更新时触发该事件，图形的平移，顶点的编辑
 
 ```javascript
-drawControl.on('draw.delete', (e) => {});
+drawControl.on('draw.delete', e => {});
 ```
 
 ### style
@@ -253,3 +253,7 @@ const style = {
   },
 };
 ```
+
+## demo
+
+<code src="./demo/draw_control.jsx" />

--- a/src/modes/draw_polygon.ts
+++ b/src/modes/draw_polygon.ts
@@ -44,6 +44,7 @@ export default class DrawPolygon extends DrawFeature {
   }
 
   public drawFinish() {
+    this.points = this.points.reverse();
     const feature = this.createFeature(this.points);
     const properties = feature.properties as { pointFeatures: Feature[] };
     this.drawLayer.update(featureCollection([feature]));
@@ -237,10 +238,10 @@ export default class DrawPolygon extends DrawFeature {
   }
   protected initData(): boolean {
     const features: Feature[] = [];
-    this.source.data.features.forEach((feature) => {
+    this.source.data.features.forEach(feature => {
       if (feature.geometry.type === 'Polygon') {
         const points = (feature.geometry.coordinates[0] as Position[]).map(
-          (coord) => {
+          coord => {
             return {
               lng: coord[0],
               lat: coord[1],


### PR DESCRIPTION
1.高德地图下，编辑多边形，点击中间顶点时产生错乱问题